### PR TITLE
[create] form-deleted per cancellare gli artisti

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "artisti_auth",
+    "name": "artisti_auth-1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/views/artist/index.blade.php
+++ b/resources/views/artist/index.blade.php
@@ -23,9 +23,7 @@
                             <a class="btn btn-warning mx-2" href="">
                                 <i class="fa-solid fa-pen-to-square"></i>
                             </a>
-                            <a class="btn btn-danger" href="">
-                                <i class="fa-solid fa-trash"></i>
-                            </a>
+                            @include('artist.partials.form-delete', ['artist'=>$artist])
                         </td>
                     </tr>
                 @endforeach

--- a/resources/views/artist/partials/form-delete.blade.php
+++ b/resources/views/artist/partials/form-delete.blade.php
@@ -1,0 +1,9 @@
+<form
+    onsubmit="return confirm('Conferma l\'eliminazione di: {{$artist->name}}')" class="d-inline"
+    action="{{route('admin.artist.destroy', $artist)}}" method="POST">
+    @csrf
+    @method('DELETE')
+    <button type="submit" class="btn btn-danger" title="delete">
+        <i class="fa-solid fa-trash"></i>
+    </button>
+</form>


### PR DESCRIPTION
creato il form delete per gli artisti e tenuto da parte il codice del destroy da inserire nella crud


    /**
     * Remove the specified resource from storage.
     *
     * @param  \App\Models\Artist $artist
     * @return \Illuminate\Http\Response
     */
    public function destroy(Artist $artist)
    {
        $artist->delete();

        return redirect()->route('admin.artist.index')->with('delete', 'Artista eliminato');
    }
